### PR TITLE
Convert char to unsigned before calling ctype.h functions

### DIFF
--- a/bscanf.c
+++ b/bscanf.c
@@ -53,7 +53,7 @@ int bscanf(const char *buffer, const char *format, ...)
 
   while ('\0' != *fmt_ptr) {
     /* We ignore spaces before specifiers. */
-    if (isspace(*fmt_ptr)) {
+    if (isspace((unsigned char)*fmt_ptr)) {
       /* Any whitespace in the format consumes all of the whitespace in the
          buffer. */
       _BSCANF_CONSUME_WSPACE();
@@ -74,7 +74,7 @@ int bscanf(const char *buffer, const char *format, ...)
       }
 
       /* Check for maximum field width. */
-      if (isdigit(*fmt_ptr)) {
+      if (isdigit((unsigned char)*fmt_ptr)) {
         max_width = strtoul(fmt_ptr, &end_ptr, 0);
         /* Check if the sequence is a number > 0. */
         _BSCANF_CHECK(fmt_ptr != end_ptr);
@@ -138,7 +138,7 @@ int bscanf(const char *buffer, const char *format, ...)
           /* Consume the character (string) and ignore it in this case. */
           for (; max_width > 0; max_width--) {
             buf_ptr++;
-            if (*buf_ptr == '\0' || (isspace(*buf_ptr) && 's' == *fmt_ptr)) {
+            if (*buf_ptr == '\0' || (isspace((unsigned char)*buf_ptr) && 's' == *fmt_ptr)) {
               break;
             }
           }
@@ -157,7 +157,7 @@ int bscanf(const char *buffer, const char *format, ...)
 
           for (; max_width > 0; max_width--) {
             *char_ptr = *buf_ptr;
-            if (*buf_ptr == '\0' || (isspace(*buf_ptr) && 's' == *fmt_ptr)) {
+            if (*buf_ptr == '\0' || (isspace((unsigned char)*buf_ptr) && 's' == *fmt_ptr)) {
               break;
             }
             char_ptr++;


### PR DESCRIPTION
the `isspace` and `isdigit` functions, like many other functions from ctype.h, actually take an `int` as the parameter, and are specified to have undefined behavior when the parameter is not in the range (-1)-255. Because it is implementation-defined whether `char` is signed or unsigned (and on most compilers targeting x86 it is actually signed), if a `char` in the range 128-254 (say, because the format string is encoded in a superset of ASCII, including UTF-8) is passed to those functions, it could be sign-extended to (-128)-(-2) and cause undefined behavior.

This patch adds manually conversion from `char` to `unsigned char` before passing them to ctype.h functions; since `unsigned char`-to-`int` conversion is zero-extension, this avoids said undefined behavior.